### PR TITLE
Make the debugger features configurable using RuntimeDebuggerEnabled

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ This file should contain the following markers, for the runtime to initialize pr
 Use the [Templates/Index.html](src/Uno.Wasm.Bootstrap/Templates/Index.html) file as an example.
 
 ### Configuration of the runtime
-- The msbuild property `RuntimeDebugLogging` can be set to `true` to allow for mono to output additional debugging details.
+- The msbuild property `MonoRuntimeDebuggerEnabled` can be set to `true` to allow for mono to output additional debugging details, and have the debugger enabled (not supported yet by the mono tooling).
 - The msbuild property `RuntimeConfiguration` allows for the selection of the debug runtime, but is mainly used for debugging the runtime itself. The value can either be `release` or `debug`.
 - The msbuild property `MonoWasmSDKUri` allows the override of the default SDK path.
 

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -63,7 +63,7 @@ namespace Uno.Wasm.Bootstrap
 		public string RuntimeConfiguration { get; set; }
 
 		[Microsoft.Build.Framework.Required]
-		public bool RuntimeDebugLogging { get; set; }
+		public bool RuntimeDebuggerEnabled { get; set; }
 
 		public override bool Execute()
 		{
@@ -279,7 +279,7 @@ namespace Uno.Wasm.Bootstrap
 					html = html.Replace("$(MAIN_NAMESPACE)", entryPoint.DeclaringType.Namespace);
 					html = html.Replace("$(MAIN_TYPENAME)", entryPoint.DeclaringType.Name);
 					html = html.Replace("$(MAIN_METHOD)", entryPoint.Name);
-					html = html.Replace("$(ENABLE_RUNTIMEDEBUG)", RuntimeDebugLogging.ToString().ToLower());
+					html = html.Replace("$(ENABLE_RUNTIMEDEBUG)", RuntimeDebuggerEnabled.ToString().ToLower());
 
 					var scripts = string.Join("\r\n", _additionalScripts.Select(s => $"<script defer type=\"text/javascript\" src=\"{s}\"></script>"));
 					html = html.Replace("$(ADDITIONAL_SCRIPTS)", scripts);

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -47,7 +47,7 @@ var MonoRuntime = {
         this.mono_string_get_utf8 = Module.cwrap('mono_wasm_string_get_utf8', 'number', ['number']);
         this.mono_string = Module.cwrap('mono_wasm_string_from_js', 'number', ['string']);
 
-        this.load_runtime("managed", 1);
+        this.load_runtime("managed", debug ? 1 : 0);
 
         if (debug) console.log("Done initializing the runtime.");
 

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -10,7 +10,7 @@
 		<WasmShellIndexHtmlPath Condition="Exists('$(_packageBinaryPath)')">$(MSBuildThisFileDirectory)../tools/templates/index.html</WasmShellIndexHtmlPath>
 
 		<MonoWasmRuntimeConfiguration Condition="'$(WasmRuntimeConfiguration)'==''">release</MonoWasmRuntimeConfiguration>
-		<MonoRuntimeDebugLogging Condition="'$(WasmRuntimeDebug)'==''">false</MonoRuntimeDebugLogging>
+		<MonoRuntimeDebuggerEnabled Condition="'$(WasmDebuggerEnabled)'==''">false</MonoRuntimeDebuggerEnabled>
 	</PropertyGroup>
 
 	<UsingTask AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.ShellTask_v0" />
@@ -23,7 +23,7 @@
 			MonoWasmSDKUri="$(MonoWasmSDKUri)"
 			IndexHtmlPath="$(WasmShellIndexHtmlPath)"
 			RuntimeConfiguration="$(MonoWasmRuntimeConfiguration)"
-			RuntimeDebugLogging="$(MonoRuntimeDebugLogging)"
+			RuntimeDebuggerEnabled="$(MonoRuntimeDebuggerEnabled)"
 			Assets="@(Content)"
 			ReferencePath="@(ReferencePath)" />
 	</Target>


### PR DESCRIPTION
Renamed MonoRuntimeDebugLogging to MonoRuntimeDebuggerEnabled, allow for the debugger to be disabled.