### PR TITLE
Improve cache-ability of the managed folder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,7 @@ This file should contain the following markers, for the runtime to initialize pr
 - `$(ENABLE_RUNTIMEDEBUG)`
 - `$(ADDITIONAL_SCRIPTS)`
 - `$(ADDITIONAL_CSS)`
+- `$(REMOTE_MANAGED_PATH)`
 
 Use the [Templates/Index.html](src/Uno.Wasm.Bootstrap/Templates/Index.html) file as an example.
 
@@ -76,8 +77,3 @@ Use the [Templates/Index.html](src/Uno.Wasm.Bootstrap/Templates/Index.html) file
 - The msbuild property `MonoRuntimeDebuggerEnabled` can be set to `true` to allow for mono to output additional debugging details, and have the debugger enabled (not supported yet by the mono tooling).
 - The msbuild property `RuntimeConfiguration` allows for the selection of the debug runtime, but is mainly used for debugging the runtime itself. The value can either be `release` or `debug`.
 - The msbuild property `MonoWasmSDKUri` allows the override of the default SDK path.
-
-## TODO
-Lots! 
-- The main missing part is the ability to change the index.html, but it should pretty easy to add.
-- The other one is the ability to use an actual release of the mono-wasm release.

--- a/src/Uno.Wasm.Bootstrap/Templates/Index.html
+++ b/src/Uno.Wasm.Bootstrap/Templates/Index.html
@@ -17,7 +17,15 @@
         document.addEventListener(
             "DOMContentLoaded",
             function (event) {
-                unoWasmMain("$(MAIN_ASSEMBLY_NAME)", "$(MAIN_NAMESPACE)", "$(MAIN_TYPENAME)", "$(MAIN_METHOD)", assemblies, $(ENABLE_RUNTIMEDEBUG));
+                unoWasmMain(
+                    "$(MAIN_ASSEMBLY_NAME)",
+                    "$(MAIN_NAMESPACE)",
+                    "$(MAIN_TYPENAME)",
+                    "$(MAIN_METHOD)",
+                    assemblies,
+                    "$(REMOTE_MANAGED_PATH)",
+                    $(ENABLE_RUNTIMEDEBUG)
+                );
             }
         );
     </script>

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -1,9 +1,10 @@
 ﻿var debug = false;
 
 
-function unoWasmMain(mainAsmName, mainNamespace, mainClassName, mainMethodName, assemblies, isDebug) {
+function unoWasmMain(mainAsmName, mainNamespace, mainClassName, mainMethodName, assemblies, remoteManagedPath, isDebug) {
     Module.entryPoint = { "a": mainAsmName, "n": mainNamespace, "t": mainClassName, "m": mainMethodName };
     Module.assemblies = assemblies;
+    Module.remoteManagedPath = remoteManagedPath;
     debug = isDebug;
 }
 
@@ -17,7 +18,7 @@ var Module = {
         this.assemblies.forEach(function (asm_name) {
             if (debug) console.log("Loading", asm_name);
             ++pending;
-            fetch("managed/" + asm_name, { credentials: 'same-origin' }).then(function (response) {
+            fetch(Module.remoteManagedPath + "/" + asm_name, { credentials: 'same-origin' }).then(function (response) {
                 if (!response.ok)
                     throw "failed to load Assembly '" + asm_name + "'";
                 return response['arrayBuffer']();
@@ -95,7 +96,9 @@ var WebAssemblyApp = {
 
         this.runApp();
 
-        this.loading.hidden = true;
+        if (loading) {
+            this.loading.hidden = true;
+        }
     },
 
     runApp: function () {


### PR DESCRIPTION
Generate the managed dist path using hash to ease the cache-ability of the managed folder, and rely on the browser's caching mechanism, instead of implemented an emscripten based storage.