### PR TITLE
Avoid dll/exe filtering from antivirus software

### DIFF
--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -24,7 +24,8 @@ var Module = {
                 return response['arrayBuffer']();
             }).then(function (blob) {
                 var asm = new Uint8Array(blob);
-                Module.FS_createDataFile("managed/" + asm_name, null, asm, true, true, true);
+                var adjustedName = asm_name.replace(/\.clr(dll|exe)/i, ".$1");
+                Module.FS_createDataFile("managed/" + adjustedName, null, asm, true, true, true);
                 --pending;
                 if (pending == 0)
                     Module.bclLoadingDone();

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -28,4 +28,12 @@
 			ReferencePath="@(ReferencePath)" />
 	</Target>
 
+	<Target Name="_CleanDist" BeforeTargets="Clean">
+		<ItemGroup>
+			<_DistFilesToDelete Include="$(OutputPath)dist\**" />
+		</ItemGroup>
+
+		<Delete Files="@(_DistFilesToDelete)" />
+	</Target>
+
 </Project>

--- a/src/Uno.Wasm.Sample/Program.cs
+++ b/src/Uno.Wasm.Sample/Program.cs
@@ -24,21 +24,6 @@ namespace Uno.Wasm.Sample
 		static void Main(string[] args) 
 		{
 			Console.WriteLine("Main!");
-
-			try
-			{
-				NewMethod();
-			}
-			catch(Exception e)
-			{
-				Console.WriteLine(e);
-			}
-		}
-
-		private static void NewMethod()
-		{
-			ImmutableDictionary<string, string> s = ImmutableDictionary<string, string>.Empty;
-			Console.WriteLine($"test new method {s.Count}");
 		}
 	}
 }


### PR DESCRIPTION
This change renames dll/exe files to clrdll/clrexe files on the wire, and renames them to the original name when stored in the wasm module's file system.

Fixes #9 