### PR TITLE
Remove unused exe support, rename clrdll to clr extension

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,7 @@ This file should contain the following markers, for the runtime to initialize pr
 - `$(ADDITIONAL_SCRIPTS)`
 - `$(ADDITIONAL_CSS)`
 - `$(REMOTE_MANAGED_PATH)`
+- `$(ASSEMBLY_FILE_EXTENSION)`
 
 Use the [Templates/Index.html](src/Uno.Wasm.Bootstrap/Templates/Index.html) file as an example.
 

--- a/src/Uno.Wasm.Bootstrap/ShellTask.Linker.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.Linker.cs
@@ -90,10 +90,8 @@ namespace Uno.Wasm.Bootstrap
 			}
 
 			RenameFiles("dll");
-			RenameFiles("exe");
 
-			_linkedAsmPaths = Directory.GetFiles(_managedPath, "*.clrdll")
-				.Concat(Directory.GetFiles(_managedPath, "*.clrexe"))
+			_linkedAsmPaths = Directory.GetFiles(_managedPath, "*." + AssembliesFileExtension)
 				.OrderBy(x => Path.GetFileName(x))
 				.ToList();
 		}
@@ -107,7 +105,7 @@ namespace Uno.Wasm.Bootstrap
 		{
 			foreach (var dllFile in Directory.GetFiles(_managedPath, "*." + extension))
 			{
-				string destDirName = Path.Combine(Path.GetDirectoryName(dllFile), Path.GetFileNameWithoutExtension(dllFile) + ".clr" + extension);
+				string destDirName = Path.Combine(Path.GetDirectoryName(dllFile), Path.GetFileNameWithoutExtension(dllFile) + "." + AssembliesFileExtension);
 
 				Log.LogMessage($"Renaming {dllFile} to {destDirName}");
 				Directory.Move(dllFile, destDirName);

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -56,6 +56,8 @@ namespace Uno.Wasm.Bootstrap
 
 		public string MonoWasmSDKUri { get; set; }
 
+		public string AssembliesFileExtension { get; set; } = "clr";
+
 		public Microsoft.Build.Framework.ITaskItem[] Assets { get; set; }
 
 		public Microsoft.Build.Framework.ITaskItem[] LinkerDescriptors { get; set; }
@@ -307,6 +309,7 @@ namespace Uno.Wasm.Bootstrap
 					html = html.Replace("$(MAIN_METHOD)", entryPoint.Name);
 					html = html.Replace("$(ENABLE_RUNTIMEDEBUG)", RuntimeDebuggerEnabled.ToString().ToLower());
 					html = html.Replace("$(REMOTE_MANAGED_PATH)", Path.GetFileName(_managedPath));
+					html = html.Replace("$(ASSEMBLY_FILE_EXTENSION)", AssembliesFileExtension);
 
 					var scripts = string.Join("\r\n", _additionalScripts.Select(s => $"<script defer type=\"text/javascript\" src=\"{s}\"></script>"));
 					html = html.Replace("$(ADDITIONAL_SCRIPTS)", scripts);

--- a/src/Uno.Wasm.Bootstrap/Templates/Index.html
+++ b/src/Uno.Wasm.Bootstrap/Templates/Index.html
@@ -24,6 +24,7 @@
                     "$(MAIN_METHOD)",
                     assemblies,
                     "$(REMOTE_MANAGED_PATH)",
+                    "$(ASSEMBLY_FILE_EXTENSION)",
                     $(ENABLE_RUNTIMEDEBUG)
                 );
             }

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -8,6 +8,7 @@
 		<RootNamespace>Uno.Wasm.Bootstrap.v0</RootNamespace>
 		<PackageId>Uno.Wasm.Bootstrap</PackageId>
 		<IsTool>true</IsTool>
+		<Version>1.0.1-test.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
+++ b/src/Uno.Wasm.Bootstrap/WasmScripts/uno-bootstrap.js
@@ -1,9 +1,10 @@
 ﻿var debug = false;
 
 
-function unoWasmMain(mainAsmName, mainNamespace, mainClassName, mainMethodName, assemblies, remoteManagedPath, isDebug) {
+function unoWasmMain(mainAsmName, mainNamespace, mainClassName, mainMethodName, assemblies, remoteManagedPath, assemblyFileExtension, isDebug) {
     Module.entryPoint = { "a": mainAsmName, "n": mainNamespace, "t": mainClassName, "m": mainMethodName };
     Module.assemblies = assemblies;
+    Module.assemblyFileExtension = assemblyFileExtension;
     Module.remoteManagedPath = remoteManagedPath;
     debug = isDebug;
 }
@@ -24,7 +25,7 @@ var Module = {
                 return response['arrayBuffer']();
             }).then(function (blob) {
                 var asm = new Uint8Array(blob);
-                var adjustedName = asm_name.replace(/\.clr(dll|exe)/i, ".$1");
+                var adjustedName = asm_name.replace("." + Module.assemblyFileExtension, ".dll");
                 Module.FS_createDataFile("managed/" + adjustedName, null, asm, true, true, true);
                 --pending;
                 if (pending == 0)


### PR DESCRIPTION
This adjustment is present to workaround an incorrect classification of dll files by "Symantec Endpoint Protection".

See #10 additional details.