### PR TITLE
Adjust for PDB files in ReferenceCopyLocalPaths

### DIFF
--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -22,6 +22,14 @@
 	<UsingTask AssemblyFile="$(WasmShellTasksPath)/Uno.Wasm.Bootstrap.v0.dll" TaskName="Uno.Wasm.Bootstrap.ShellTask_v0" />
 
 	<Target Name="BuildDist" AfterTargets="AfterBuild">
+
+		<ItemGroup>
+			<!-- Filter ReferenceCopyLocalPaths as it may contain pdbs as well -->
+			<_AssembliesForReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths)"
+																						 Condition="'%(Extension)' == '.dll'" />
+		</ItemGroup>
+
+
 		<ShellTask_v0
 			Assembly="$(IntermediateOutputPath)$(TargetFileName)"
 			OutputPath="$(OutputPath)"
@@ -33,7 +41,7 @@
 			RuntimeConfiguration="$(MonoWasmRuntimeConfiguration)"
 			RuntimeDebuggerEnabled="$(MonoRuntimeDebuggerEnabled)"
 			Assets="@(Content)"
-			ReferencePath="@(ReferenceCopyLocalPaths)" />
+			ReferencePath="@(_AssembliesForReferenceCopyLocalPaths)" />
 	</Target>
 
 	<Target Name="_CleanDist" BeforeTargets="Clean">


### PR DESCRIPTION
This fixes an issue where pdb files were loaded as part of the ReferenceCopyLocalPath items:

```
2>packages\uno.wasm.bootstrap\1.0.0-dev.34\build\Uno.Wasm.Bootstrap.targets(25,3): error : AggregateException: One or more errors occurred.
2>packages\uno.wasm.bootstrap\1.0.0-dev.34\build\Uno.Wasm.Bootstrap.targets(25,3): error : BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
```