### PR TITLE
Adjust invalid nuget layout

### DIFF
--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -30,11 +30,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="build/Uno.Wasm.Bootstrap.targets">
-			<Pack>true</Pack>
-			<PackagePath>build</PackagePath>
-		</Content>
-		<Content Include="build/packager.cs">
+    <Content Include="build/*.targets">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+    <Content Include="build/*.props">
+      <Pack>true</Pack>
+      <PackagePath>build</PackagePath>
+    </Content>
+    <Content Include="build/packager.cs">
 			<Pack>true</Pack>
 			<PackagePath>build</PackagePath>
 		</Content>
@@ -44,7 +48,7 @@
     </Content>
     <Content Include="build/linker/**">
       <Pack>true</Pack>
-      <PackagePath>build/CustomDebuggerProxy</PackagePath>
+      <PackagePath>build/linker</PackagePath>
     </Content>
     <Content Include="Templates\index.html">
 			<Pack>true</Pack>


### PR DESCRIPTION
Fixes #42 

The nuget files in the resulting layout was incorrect, breaking the targets import and the linker.