### PR TITLE
Update the default background color to match default UWP

### DIFF
--- a/src/Uno.Wasm.Bootstrap/WasmCSS/uno-bootstrap.css
+++ b/src/Uno.Wasm.Bootstrap/WasmCSS/uno-bootstrap.css
@@ -5,7 +5,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: var(--bg-color, #242424);
+    background-color: var(--bg-color, white);
 }
 
     .uno-loader .logo {


### PR DESCRIPTION
This change is meant to be neutral, until configurability of the loading screen is added (current behavior with UnoAppManifest relies on Uno.UI being present, which is not always the case).