### PR TITLE
Add support for index.html Content prefetching

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -234,6 +234,15 @@ You can deactivate this feature by setting this property in your `.csproj` file:
 <WashShellUseFileIntegrity>False</WashShellUseFileIntegrity>
 ```
 
+### Support for Content prefetching
+The `WashShellGeneratePrefetchHeaders` controls the generation of `<link rel="prefetch" />` nodes in the index.html header.
+
+It is enabled by default and allows for the browser to efficiently fetch the applications
+webassembly and .NET assemblies files, while the JavaScript and WebAssembly runtimes are 
+being initialized.
+
+This prefetching feature is particularly useful if the http server supports HTTP/2.0.
+
 ## Environment variables
 Mono provides the ability to configure some features at initialization, such as logging or GC.
 

--- a/src/Uno.Wasm.Bootstrap/ShellTask.cs
+++ b/src/Uno.Wasm.Bootstrap/ShellTask.cs
@@ -879,7 +879,6 @@ namespace Uno.Wasm.Bootstrap
 
 						// See https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html
 						extraBuilder.AppendLine($"<meta name=\"apple-mobile-web-app-capable\" content=\"yes\">");
-						extraBuilder.AppendLine($"<meta name=\"apple-mobile-web-app-status-bar-style\" content=\"black-translucent\">");
 
 						if (manifestDocument["icons"] is JArray array
 							&& array.Where(v => v["sizes"]?.Value<string>() == "1024x1024").FirstOrDefault() is JToken img)

--- a/src/Uno.Wasm.Bootstrap/Templates/index.html
+++ b/src/Uno.Wasm.Bootstrap/Templates/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+
     <script defer type="text/javascript" src="require.js"></script>
     <script type="text/javascript" src="mono-config.js"></script>
     <script type="text/javascript" src="uno-config.js"></script>

--- a/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
+++ b/src/Uno.Wasm.Bootstrap/Uno.Wasm.Bootstrap.csproj
@@ -61,33 +61,39 @@
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</Content>
 		<Content Include="$(NuGetPackageRoot)/system.runtime.compilerservices.unsafe/4.5.2/lib/netstandard2.0/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</Content>
 		<Content Include="$(NuGetPackageRoot)/mono.cecil/0.10.1/lib/netstandard1.3/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
+			<Visible>false</Visible>
 		</Content>
 		<Content Include="$(NuGetPackageRoot)/mono.cecil/0.10.1/lib/netstandard1.3/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<Visible>false</Visible>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</Content>
 		<Content Include="$(NuGetPackageRoot)/mono.options/5.3.0.1/lib/netstandard1.3/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<Visible>false</Visible>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</Content>
 		<Content Include="$(NuGetPackageRoot)/newtonsoft.json/12.0.1/lib/netstandard2.0/*.dll">
 			<Pack>true</Pack>
 			<PackagePath>tools</PackagePath>
 			<Visible>false</Visible>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Visible>false</Visible>
 		</Content>
 	</ItemGroup>
 

--- a/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
+++ b/src/Uno.Wasm.Bootstrap/build/Uno.Wasm.Bootstrap.targets
@@ -125,6 +125,7 @@
         MonoWasmSDKPath="$(_UnoMonoSdkPath)"
         PackagerBinPath="$(_UnoMonoPackagerBinPath)"
         UseFileIntegrity="$(WashShellUseFileIntegrity)"
+        GeneratePrefetchHeaders="$(WashShellGeneratePrefetchHeaders)"
         PWAManifestFile="$(WasmPWAManifestFile)"
         IndexHtmlPath="$(WasmShellIndexHtmlPath)"
         RuntimeConfiguration="$(MonoWasmRuntimeConfiguration)"


### PR DESCRIPTION
The `WashShellGeneratePrefetchHeaders` controls the generation of `<link rel="prefetch" />` nodes in the index.html header. 

It is enabled by default and allows for the browser to efficiently fetch the applications webassembly and .NET assemblies files, while the JavaScript and WebAssembly runtimes are  being initialized. 

This prefetching feature is particularly useful if the http server supports HTTP/2.0.